### PR TITLE
装饰器初始化时，可以定位出错位置

### DIFF
--- a/src/containers/App/index.js
+++ b/src/containers/App/index.js
@@ -7,6 +7,7 @@ import { isLoaded as isAuthLoaded, load as loadAuth } from 'redux/modules/auth';
 import { helmet } from 'config';
 
 @asyncConnect([{
+  key: 'AppInit',
   promise: ({ store: { dispatch, getState } }) => {
     const promises = [];
 

--- a/src/containers/Test/index.js
+++ b/src/containers/Test/index.js
@@ -8,6 +8,7 @@ import testActions, { isLoaded, load as loadTest } from 'redux/modules/test';
 import Header from 'components/Header';
 
 @asyncConnect([{
+  key: 'TestInit',
   deferred: true,
   // eslint-disable-next-line
   promise: ({store: {dispatch, getState}}) => {

--- a/src/helpers/ApiClient.js
+++ b/src/helpers/ApiClient.js
@@ -15,12 +15,22 @@ function formatUrl(url) {
   return adjustedUrl;
 }
 
+function createRequest(method, url, timeout) {
+  const request = superagent[method](url);
+  if (timeout) request.timeout(timeout);
+  request.catch((e) => {
+    e.message = `${url} ${e.message}`;
+    e.url = url;
+  });
+  return request;
+}
+
 export default class ApiClient {
   constructor(ctx) {
     methods.forEach((method) => {
       this[method] = (path, { params, data } = {}) => new Promise((resolve, reject) => {
         console.log('-----------fetch url: ', formatUrl(path));
-        const request = superagent[method](formatUrl(path));
+        const request = createRequest(method, formatUrl(path));
 
         if (params) {
           request.query(params);
@@ -35,7 +45,7 @@ export default class ApiClient {
         }
 
         // eslint-disable-next-line
-        request.end((err, { body } = {}) => err ? reject(body || err) : resolve(body));
+        request.end((err, { body } = {}) => err ? reject(err) : resolve(body));
       });
     });
   }


### PR DESCRIPTION
装饰器初始化时，可以定位出错位置。
涉及到两个组件
1个 superagent                    出错后给出url
1个redux-async-connect    出错后抛出错误