### PR TITLE
Not Found route problem and PropTypes warning.

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "offline-plugin": "^4.6.2",
     "postcss-loader": "^1.3.3",
     "pretty-error": "^2.1.0",
+    "prop-types": "^15.5.8",
     "react": "^15.5.3",
     "react-a11y": "^0.3.3",
     "react-dom": "^15.5.3",

--- a/src/components/RegistryForm/index.js
+++ b/src/components/RegistryForm/index.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { Field, reduxForm } from 'redux-form';
 
 @reduxForm({

--- a/src/containers/About/index.js
+++ b/src/containers/About/index.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import Helmet from 'react-helmet';
 import cx from 'classnames';
 import styles from './About.less';

--- a/src/containers/App/index.js
+++ b/src/containers/App/index.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import Helmet from 'react-helmet';
 import { push } from 'react-router-redux';

--- a/src/containers/Home/index.js
+++ b/src/containers/Home/index.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import Helmet from 'react-helmet';
 import { connect } from 'react-redux';
 import { asyncConnect } from 'redux-async-connect';

--- a/src/helpers/Html.js
+++ b/src/helpers/Html.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import ReactDOM from 'react-dom/server';
 import serialize from 'serialize-javascript';
 import Helmet from 'react-helmet';

--- a/src/routes.js
+++ b/src/routes.js
@@ -46,7 +46,7 @@ export default (/* store */) => {
       {/* Catch all route */}
       <Route
         path="*"
-        getComponent={NotFound}
+        component={NotFound}
         status={404}
       />
     </Route>

--- a/yarn.lock
+++ b/yarn.lock
@@ -5594,6 +5594,12 @@ prop-types@^15.0.0, prop-types@^15.5.2, prop-types@^15.5.4, prop-types@^15.5.6, 
   dependencies:
     fbjs "^0.8.9"
 
+prop-types@^15.5.8:
+  version "15.5.8"
+  resolved "http://registry.npm.taobao.org/prop-types/download/prop-types-15.5.8.tgz#6b7b2e141083be38c8595aa51fc55775c7199394"
+  dependencies:
+    fbjs "^0.8.9"
+
 prr@~0.0.0:
   version "0.0.0"
   resolved "https://registry.yarnpkg.com/prr/-/prr-0.0.0.tgz#1a84b85908325501411853d0081ee3fa86e2926a"


### PR DESCRIPTION
src/routes.js:
Modified Line 49: 
```jsx
// getComponent={NotFound}
component={NotFound}
```

And:
Warning: Accessing PropTypes via the main React package is deprecated. Use the prop-types package from npm instead.

> P.S. There is still a warning about PropTypes because of the package `redux-async-connect` which still using `React.PropTypes`.